### PR TITLE
Terminate transcode on exit.

### DIFF
--- a/src/Captbaritone/TranscodeToMp3Stream/Pipe.php
+++ b/src/Captbaritone/TranscodeToMp3Stream/Pipe.php
@@ -4,24 +4,33 @@ class Pipe
 {
 
     private $handle;
+    private $pipes;
 
-    public function open($cmd, $mode)
+    public function open($cmd)
     {
-        $this->handle = popen($cmd, $mode);
+        $this->handle = proc_open($cmd, [ 1 => [ 'pipe', 'w' ] ], $this->pipes);
+        register_shutdown_function( [ $this, 'terminate' ] );
     }
 
     public function fread($bytes)
     {
-        return fread($this->handle, $bytes);
+        return fread($this->pipes[1], $bytes);
     }
 
     public function feof()
     {
-        return feof($this->handle);
+        return feof($this->pipes[1]);
     }
 
     public function close()
     {
+        fclose($this->pipes[1]);
         return pclose($this->handle);
     }
+
+    public function terminate()
+    {
+        return proc_terminate($this->handle);
+    }
+
 }

--- a/src/Captbaritone/TranscodeToMp3Stream/Streamer.php
+++ b/src/Captbaritone/TranscodeToMp3Stream/Streamer.php
@@ -14,7 +14,7 @@ class Streamer
 
     public function outputStream($cmd, $byteGoal)
     {
-        $this->pipe->open($cmd, 'r');
+        $this->pipe->open($cmd);
 
         // Initilize our count of bytes sent
         $outputSize = 0;

--- a/src/Captbaritone/TranscodeToMp3Stream/Transcoder.php
+++ b/src/Captbaritone/TranscodeToMp3Stream/Transcoder.php
@@ -18,6 +18,7 @@ class Transcoder
         $duration = escapeshellarg($duration);
 
         $args = array();
+        $args[] = "exec";
         $args[] = "avconv";
         if($haveStart) $args[] = "-ss {$start}";
         if($haveDuration) $args[] = "-t {$duration}";

--- a/tests/TranscoderTest.php
+++ b/tests/TranscoderTest.php
@@ -17,7 +17,7 @@ class TranscoderTest extends \PHPUnit_Framework_TestCase
 
         $command = $transcoder->command('testfile.flac', 'KBPS', 'start', 'end');
 
-        $expected = "avconv -ss 'start' -t 'end' -i 'testfile.flac' -ab 'KBPSk' -minrate 'KBPSk' -maxrate 'KBPSk' -bufsize 64k -f mp3 -map_metadata -1  - 2>/dev/null";
+        $expected = "exec avconv -ss 'start' -t 'end' -i 'testfile.flac' -ab 'KBPSk' -minrate 'KBPSk' -maxrate 'KBPSk' -bufsize 64k -f mp3 -map_metadata -1  - 2>/dev/null";
 
         $this->assertEquals($command, $expected);
     }


### PR DESCRIPTION
Currently once a transcode is started - it runs to the end, even if the user cancels the download or closes the browser.

These changes allow PHP to terminate the transcode process when the script stops running.